### PR TITLE
Fix deleting FIS experiment template

### DIFF
--- a/pkg/itn/itn.go
+++ b/pkg/itn/itn.go
@@ -94,6 +94,7 @@ func (i ITN) Interrupt(ctx context.Context, instanceIDs []string, delay time.Dur
 	}
 	events := make(chan Event, 10)
 	go func() {
+		defer close(events)
 		if clean {
 			defer func() {
 				if err := i.Clean(ctx, *experiment); err != nil {
@@ -104,7 +105,6 @@ func (i ITN) Interrupt(ctx context.Context, instanceIDs []string, delay time.Dur
 				}
 			}()
 		}
-		defer close(events)
 		if err := i.monitor(ctx, events, experiment, delay); err != nil {
 			events <- Event{
 				Timestamp: time.Now(),


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-ec2-spot-interrupter/issues/11 

*Description of changes:*
* Move `defer close(events)` to the bottom of stack so that `i.Clean()` can execute first, if enabled

*Root cause:*
* `close(events)` executes before `i.Clean()` because it is placed on the stack last. After closing the events channel, the app will exit before sending `DeleteExperimentTemplate` request. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
