### PR TITLE
Run e2e tests for PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Integration Tests
+    - name: Integration Test
       run: make e2e-test
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,4 +24,3 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
-        AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,27 @@
+name: spot-interrupter ci workflows
+
+on: [pull_request, workflow_dispatch]
+
+env:
+  DEFAULT_GO_VERSION: ^1.18
+
+jobs:
+  buildAndTest:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.DEFAULT_GO_VERSION }}
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Integration Tests
+      run: make e2e-test
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
+        AWS_REGION: ${{ secrets.AWS_REGION }}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
* adds workflow to run e2e tests against PRs
* outside contributors (non-maintainers) will need approval from a maintainer before tests kickoff to prevent abuse. From [docs](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks):
* > To help prevent this, workflows on pull requests to public repositories from some outside contributors will not run automatically, and might need to be approved first.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
