### PR TITLE
GoReleaser config updates

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,6 +4,10 @@ before:
     - go mod tidy
 builds:
   - main: ./cmd/main.go
+    # update ldflags and mod_timestamp to ensure reproducible builds
+    ldflags:
+      - -s -w -X main.build={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}} -X main.builtBy=goreleaser
+    mod_timestamp: '{{ .CommitTimestamp }}'
     env:
       - CGO_ENABLED=0
     targets:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,8 +20,6 @@ archives:
   - replacements:
       darwin: Darwin
       linux: Linux
-checksum:
-  name_template: 'checksums.txt'
 snapshot:
   name_template: "{{ incpatch .Version }}-snapshot"
 changelog:


### PR DESCRIPTION
**Issue #, if available:** N/A, checksum not matching when publishing to `homebrew-tap`

**Description of changes:**
* Override default build args to ensure _reproducible builds_ per [docs](https://goreleaser.com/customization/build/?h=reprod#reproducible-builds)
* Remove `checksum` config to revert filename because the default value is clearer. Ex `ec2-spot-interrupter_0.0.8-snapshot_checksums.txt`

**Verification**
* `goreleaser check`
* Compared checksum values by running the release locally:
  * `goreleaser release --snapshot`
  * documented values in `dist/checksum.txt`, delete the folder, and re-run
  * before changes, the values in `checksum.txt` would always change when invoking `gorelease release`
  * after changes, these values remain the same

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
