### PR TITLE
update ci config to use pull_request_target securely

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,14 +1,23 @@
-name: spot-interrupter ci workflows
+name: spot-interrupter build and test
 
-on: [pull_request, workflow_dispatch]
+on: [pull_request_target, workflow_dispatch]
 
 env:
   DEFAULT_GO_VERSION: ^1.18
 
 jobs:
+  approve:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Approve
+      run: echo Pull requests require approval before running any automated CI.
+
   buildAndTest:
     name: Build and Test
     runs-on: ubuntu-latest
+    needs: [approve]
+    environment:
+      name: Pull Request Integration
     steps:
     - name: Set up Go
       uses: actions/setup-go@v2
@@ -17,6 +26,8 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Integration Test
       run: make e2e-test


### PR DESCRIPTION
*Issue #, if available:* N/A. Credentials are not passed on `pull_request` trigger from public forks for security reasons; however, we would like to run integ tests against new changes before merging the code.

*Description of changes:*
* updated `pull_request` to `pull_request_target` event to provide secrets to forks securely. [docs](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks)
* created [Pull Request Integration](https://github.com/aws/amazon-ec2-spot-interrupter/settings/environments) environment which requires team approval before kicking off workflows. [docs](https://github.blog/changelog/2020-12-15-github-actions-environments-environment-protection-rules-and-environment-secrets-beta/)
* added 'approve' job for transparency


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
