### PR TITLE
Remove datetime from ldflags in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,7 @@ builds:
   - main: ./cmd/main.go
     # update ldflags and mod_timestamp to ensure reproducible builds
     ldflags:
-      - -s -w -X main.build={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}} -X main.builtBy=goreleaser
+      - -s -w -X main.build={{.Version}} -X main.commit={{.Commit}} -X main.builtBy=goreleaser
     mod_timestamp: '{{ .CommitTimestamp }}'
     env:
       - CGO_ENABLED=0


### PR DESCRIPTION
*Issue #, if available:* N/A, GHA produced different checksum from Mac due to time formatting differences

*Description of changes:*
* Removes any date/time refs from the build to ensure reproducibility 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
