### PR TITLE
Add `ITN` unit tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,9 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
+    - name: Unit Test
+      run: go test -bench=. ./pkg/... -v -coverprofile=coverage.out -covermode=atomic
+
     - name: Integration Test
       run: make e2e-test
       env:

--- a/pkg/itn/itn.go
+++ b/pkg/itn/itn.go
@@ -65,20 +65,20 @@ const (
 )
 
 type ITN struct {
-	cfg    aws.Config
-	stsAPI *sts.Client
-	fisAPI *fis.Client
-	iamAPI *iam.Client
-	ec2API *ec2.Client
+	cfg       aws.Config
+	stsClient stsAPI
+	fisClient fisAPI
+	iamClient iamAPI
+	ec2Client ec2API
 }
 
 func New(cfg aws.Config) *ITN {
 	return &ITN{
-		cfg:    cfg,
-		stsAPI: sts.NewFromConfig(cfg),
-		fisAPI: fis.NewFromConfig(cfg),
-		iamAPI: iam.NewFromConfig(cfg),
-		ec2API: ec2.NewFromConfig(cfg),
+		cfg:       cfg,
+		stsClient: sts.NewFromConfig(cfg),
+		fisClient: fis.NewFromConfig(cfg),
+		iamClient: iam.NewFromConfig(cfg),
+		ec2Client: ec2.NewFromConfig(cfg),
 	}
 }
 
@@ -119,7 +119,7 @@ func (i ITN) validate(ctx context.Context, instanceIDs []string) error {
 	if len(instanceIDs) == 0 {
 		return errors.New("no instances specified")
 	}
-	paginator := ec2.NewDescribeInstancesPaginator(i.ec2API, &ec2.DescribeInstancesInput{InstanceIds: instanceIDs})
+	paginator := ec2.NewDescribeInstancesPaginator(i.ec2Client, &ec2.DescribeInstancesInput{InstanceIds: instanceIDs})
 	var instances []ec2types.Instance
 	for paginator.HasMorePages() {
 		out, err := paginator.NextPage(ctx)
@@ -143,7 +143,7 @@ func (i ITN) validate(ctx context.Context, instanceIDs []string) error {
 }
 
 func (i ITN) SpotInstances(ctx context.Context) ([]ec2types.Instance, error) {
-	paginator := ec2.NewDescribeInstancesPaginator(i.ec2API, &ec2.DescribeInstancesInput{
+	paginator := ec2.NewDescribeInstancesPaginator(i.ec2Client, &ec2.DescribeInstancesInput{
 		Filters: []ec2types.Filter{
 			{
 				Name:   aws.String("instance-lifecycle"),
@@ -170,7 +170,7 @@ func (i ITN) SpotInstances(ctx context.Context) ([]ec2types.Instance, error) {
 
 // Clean deletes the generated experiment template from FIS
 func (i ITN) Clean(ctx context.Context, experiment types.Experiment) error {
-	_, err := i.fisAPI.DeleteExperimentTemplate(ctx, &fis.DeleteExperimentTemplateInput{Id: experiment.ExperimentTemplateId})
+	_, err := i.fisClient.DeleteExperimentTemplate(ctx, &fis.DeleteExperimentTemplateInput{Id: experiment.ExperimentTemplateId})
 	return err
 }
 
@@ -198,7 +198,7 @@ func (i ITN) monitor(ctx context.Context, events chan Event, experiment *types.E
 	for {
 		select {
 		case <-ticker.C:
-			experimentUpdate, err := i.fisAPI.GetExperiment(ctx, &fis.GetExperimentInput{Id: experiment.Id})
+			experimentUpdate, err := i.fisClient.GetExperiment(ctx, &fis.GetExperimentInput{Id: experiment.Id})
 			if err != nil {
 				return err
 			}
@@ -267,11 +267,11 @@ func (i ITN) createInterruptions(ctx context.Context, instanceIDs []string, dela
 			ResourceArns:  i.instanceIDsToARNs(batch, i.cfg.Region, accountID),
 		}
 	}
-	experimentTemplate, err := i.fisAPI.CreateExperimentTemplate(ctx, template)
+	experimentTemplate, err := i.fisClient.CreateExperimentTemplate(ctx, template)
 	if err != nil {
 		return nil, err
 	}
-	experiment, err := i.fisAPI.StartExperiment(ctx, &fis.StartExperimentInput{ExperimentTemplateId: experimentTemplate.ExperimentTemplate.Id})
+	experiment, err := i.fisClient.StartExperiment(ctx, &fis.StartExperimentInput{ExperimentTemplateId: experimentTemplate.ExperimentTemplate.Id})
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +296,7 @@ func (i ITN) batchInstances(instanceIDs []string, size int) [][]string {
 
 func (i ITN) getOrCreateFISRole(ctx context.Context, accountID string) (*string, error) {
 	roleName := "aws-fis-itn"
-	out, err := i.iamAPI.CreateRole(ctx, &iam.CreateRoleInput{
+	out, err := i.iamClient.CreateRole(ctx, &iam.CreateRoleInput{
 		RoleName:                 ptr.String(roleName),
 		AssumeRolePolicyDocument: ptr.String(trustPolicy),
 	})
@@ -307,7 +307,7 @@ func (i ITN) getOrCreateFISRole(ctx context.Context, accountID string) (*string,
 	if err != nil {
 		return nil, err
 	}
-	_, err = i.iamAPI.PutRolePolicy(ctx, &iam.PutRolePolicyInput{
+	_, err = i.iamClient.PutRolePolicy(ctx, &iam.PutRolePolicyInput{
 		PolicyName:     ptr.String(fmt.Sprintf("%s-policy", roleName)),
 		PolicyDocument: ptr.String(rolePolicy),
 		RoleName:       out.Role.RoleName,
@@ -319,7 +319,7 @@ func (i ITN) getOrCreateFISRole(ctx context.Context, accountID string) (*string,
 }
 
 func (i ITN) getAccountID(ctx context.Context) (string, error) {
-	identity, err := i.stsAPI.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	identity, err := i.stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 	if err != nil {
 		return "", err
 	}

--- a/pkg/itn/itn_test.go
+++ b/pkg/itn/itn_test.go
@@ -1,0 +1,303 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package itn
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	h "github.com/aws/itn/pkg/test"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/fis"
+	"github.com/aws/aws-sdk-go-v2/service/fis/types"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+const (
+	mockAccountID = "12345"
+	mockRegion    = "us-weast-2"
+)
+
+func TestCreateInterruptions(t *testing.T) {
+	ctx := context.Background()
+	instanceIDs := []string{"InstanceID-1"}
+	itn := ITN{
+		cfg: aws.Config{
+			Region: mockRegion,
+		},
+		fisClient: &fisMockClient{},
+		iamClient: &iamMockClient{},
+		stsClient: &stsMockClient{},
+	}
+	mockedDelay := time.Second * 5
+	output, err := itn.createInterruptions(ctx, instanceIDs, time.Duration(mockedDelay))
+	h.Ok(t, err)
+	h.Equals(t, fmt.Sprintf("arn:aws:iam::%s:role/%s", mockAccountID, fisRoleName), *output.RoleArn)
+	h.Equals(t, "none", *output.StopConditions[0].Source)
+
+	// validate Actions
+	actualAction := output.Actions["itn0"]
+	h.Equals(t, "aws:ec2:send-spot-instance-interruptions", *actualAction.ActionId)
+	h.Equals(t, "trigger spot ITN for instances [InstanceID-1]", *actualAction.Description)
+	h.Equals(t, "PT125S", actualAction.Parameters["durationBeforeInterruption"])
+	h.Equals(t, "itn0", actualAction.Targets["SpotInstances"])
+
+	// validate Targets
+	actualTarget := output.Targets["itn0"]
+	h.Equals(t, []string{"arn:aws:ec2:us-weast-2:12345:instance/InstanceID-1"}, actualTarget.ResourceArns)
+	h.Equals(t, "aws:ec2:spot-instance", *actualTarget.ResourceType)
+	h.Equals(t, "ALL", *actualTarget.SelectionMode)
+}
+
+func TestValidate(t *testing.T) {
+	// no instances
+	ctx := context.Background()
+	instanceIDs := []string{}
+	itn := ITN{}
+	err := itn.validate(ctx, instanceIDs)
+	h.Nok(t, err)
+	h.Equals(t, "no instances specified", err.Error())
+
+	/*
+		TODO(brycahta@) after refactoring pager:
+		- no errors
+		- spot/running instances cases
+	*/
+
+}
+
+func TestGetOrCreateFISRole(t *testing.T) {
+	ctx := context.Background()
+	itn := ITN{
+		iamClient: &iamMockClient{},
+	}
+	out, err := itn.getOrCreateFISRole(ctx, mockAccountID)
+	h.Equals(t, fmt.Sprintf("arn:aws:iam::%s:role/%s", mockAccountID, fisRoleName), *out)
+	h.Ok(t, err)
+
+	// role already exists
+	updatedContext := context.WithValue(ctx, "roleExists", "yup")
+	out, err = itn.getOrCreateFISRole(updatedContext, mockAccountID)
+	h.Equals(t, fmt.Sprintf("arn:aws:iam::%s:role/%s", mockAccountID, fisRoleName), *out)
+	h.Ok(t, err)
+}
+
+func TestGetAccountID(t *testing.T) {
+	ctx := context.Background()
+	itn := ITN{
+		stsClient: &stsMockClient{},
+	}
+	resp, err := itn.getAccountID(ctx)
+	h.Equals(t, mockAccountID, resp)
+	h.Ok(t, err)
+}
+
+func TestARNToInstanceID(t *testing.T) {
+	expectedInstanceID := "someID"
+	mockedARN := fmt.Sprintf("arn:aws:ec2:%s:%s:instance/%s", mockRegion, mockAccountID, expectedInstanceID)
+	h.Equals(t, expectedInstanceID, ARNToInstanceID(mockedARN))
+}
+
+func TestInstanceIDsToARNs(t *testing.T) {
+	instanceIDs := []string{"some", "instance", "ids"}
+	mockedARNPrefix := fmt.Sprintf("arn:aws:ec2:%s:%s:instance/", mockRegion, mockAccountID)
+	expectedARNs := []string{
+		mockedARNPrefix + "some",
+		mockedARNPrefix + "instance",
+		mockedARNPrefix + "ids",
+	}
+	itn := ITN{}
+	out := itn.instanceIDsToARNs(instanceIDs, mockRegion, mockAccountID)
+	h.Equals(t, expectedARNs, out)
+}
+
+func TestBatchInstances(t *testing.T) {
+	instanceIDs := []string{}
+	expectedBatches := [][]string{}
+	itn := ITN{}
+	// empty
+	out := itn.batchInstances(instanceIDs, fisTargetLimit)
+	h.Equals(t, expectedBatches, out)
+
+	// < 5
+	instanceIDs = []string{"some", "instance", "ids"}
+	expectedBatches = [][]string{
+		{"some", "instance", "ids"},
+	}
+	out = itn.batchInstances(instanceIDs, fisTargetLimit)
+	h.Equals(t, expectedBatches, out)
+
+	// multiple of 5
+	instanceIDs = []string{
+		"some",
+		"instance",
+		"ids",
+		"four",
+		"five",
+		"six",
+		"seven",
+		"eight",
+		"nine",
+		"ten",
+	}
+	expectedBatches = [][]string{
+		{"some", "instance", "ids", "four", "five"},
+		{"six", "seven", "eight", "nine", "ten"},
+	}
+	out = itn.batchInstances(instanceIDs, fisTargetLimit)
+	h.Equals(t, expectedBatches, out)
+
+	// > 5
+	instanceIDs = []string{
+		"some",
+		"instance",
+		"ids",
+		"four",
+		"five",
+		"six",
+		"seven",
+		"eight",
+		"nine",
+		"ten",
+		"three",
+		"more",
+		"instances",
+	}
+	expectedBatches = [][]string{
+		{"some", "instance", "ids", "four", "five"},
+		{"six", "seven", "eight", "nine", "ten"},
+		{"three", "more", "instances"},
+	}
+	out = itn.batchInstances(instanceIDs, fisTargetLimit)
+	h.Equals(t, expectedBatches, out)
+}
+
+// Mocks
+
+type fisMockClient struct {
+	experimentTemplate fis.CreateExperimentTemplateOutput
+}
+type iamMockClient struct{}
+type stsMockClient struct{}
+
+func (f *fisMockClient) CreateExperimentTemplate(ctx context.Context, params *fis.CreateExperimentTemplateInput, optFns ...func(*fis.Options)) (*fis.CreateExperimentTemplateOutput, error) {
+	mockedAction := types.ExperimentTemplateAction{
+		ActionId:    params.Actions["itn0"].ActionId,
+		Description: params.Description,
+		Parameters:  params.Actions["itn0"].Parameters,
+		Targets:     params.Actions["itn0"].Targets,
+	}
+	mockedActions := map[string]types.ExperimentTemplateAction{
+		"itn0": mockedAction,
+	}
+	mockedStop := types.ExperimentTemplateStopCondition{
+		Source: params.StopConditions[0].Source,
+	}
+	mockedTarget := types.ExperimentTemplateTarget{
+		ResourceArns:  params.Targets["itn0"].ResourceArns,
+		ResourceType:  params.Targets["itn0"].ResourceType,
+		SelectionMode: params.Targets["itn0"].SelectionMode,
+	}
+	mockedTargets := map[string]types.ExperimentTemplateTarget{
+		"itn0": mockedTarget,
+	}
+	mockedID := "id-12345"
+	output := fis.CreateExperimentTemplateOutput{
+		ExperimentTemplate: &types.ExperimentTemplate{
+			Actions:        mockedActions,
+			Description:    params.Description,
+			Id:             &mockedID,
+			RoleArn:        params.RoleArn,
+			StopConditions: []types.ExperimentTemplateStopCondition{mockedStop},
+			Targets:        mockedTargets,
+		},
+	}
+	f.experimentTemplate = output
+	return &output, nil
+}
+
+func (f *fisMockClient) DeleteExperimentTemplate(ctx context.Context, params *fis.DeleteExperimentTemplateInput, optFns ...func(*fis.Options)) (*fis.DeleteExperimentTemplateOutput, error) {
+	return nil, nil
+}
+
+func (f *fisMockClient) GetExperiment(ctx context.Context, params *fis.GetExperimentInput, optFns ...func(*fis.Options)) (*fis.GetExperimentOutput, error) {
+	return nil, nil
+}
+
+func (f *fisMockClient) StartExperiment(ctx context.Context, params *fis.StartExperimentInput, optFns ...func(*fis.Options)) (*fis.StartExperimentOutput, error) {
+	mockedExpTemplate := f.experimentTemplate.ExperimentTemplate
+	mockedAction := types.ExperimentAction{
+		ActionId:    mockedExpTemplate.Actions["itn0"].ActionId,
+		Description: mockedExpTemplate.Actions["itn0"].Description,
+		Parameters:  mockedExpTemplate.Actions["itn0"].Parameters,
+		Targets:     mockedExpTemplate.Actions["itn0"].Targets,
+	}
+	mockedActions := map[string]types.ExperimentAction{
+		"itn0": mockedAction,
+	}
+	mockedStop := types.ExperimentStopCondition{
+		Source: mockedExpTemplate.StopConditions[0].Source,
+	}
+	mockedTarget := types.ExperimentTarget{
+		ResourceArns:  mockedExpTemplate.Targets["itn0"].ResourceArns,
+		ResourceType:  mockedExpTemplate.Targets["itn0"].ResourceType,
+		SelectionMode: mockedExpTemplate.Targets["itn0"].SelectionMode,
+	}
+	mockedTargets := map[string]types.ExperimentTarget{
+		"itn0": mockedTarget,
+	}
+	output := fis.StartExperimentOutput{
+		Experiment: &types.Experiment{
+			Actions:        mockedActions,
+			RoleArn:        mockedExpTemplate.RoleArn,
+			StopConditions: []types.ExperimentStopCondition{mockedStop},
+			Targets:        mockedTargets,
+		},
+	}
+	return &output, nil
+}
+
+func (i *iamMockClient) CreateRole(ctx context.Context, params *iam.CreateRoleInput, optFns ...func(*iam.Options)) (*iam.CreateRoleOutput, error) {
+	if ctx.Value("roleExists") != nil {
+		var alreadyExists *iamtypes.EntityAlreadyExistsException
+		return nil, alreadyExists
+	}
+	mockRoleARN := fmt.Sprintf("arn:aws:iam::%s:role/%s", mockAccountID, fisRoleName)
+	// cannot take address of const
+	roleName := fisRoleName
+	out := iam.CreateRoleOutput{
+		Role: &iamtypes.Role{
+			Arn:      &mockRoleARN,
+			RoleName: &roleName,
+		},
+	}
+	return &out, nil
+}
+
+func (i *iamMockClient) PutRolePolicy(ctx context.Context, params *iam.PutRolePolicyInput, optFns ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error) {
+	return nil, nil
+}
+
+func (s *stsMockClient) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	mockAcct := mockAccountID
+	out := sts.GetCallerIdentityOutput{
+		Account: &mockAcct,
+	}
+	return &out, nil
+}

--- a/pkg/itn/types.go
+++ b/pkg/itn/types.go
@@ -1,0 +1,43 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package itn
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/fis"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+type ec2API interface {
+	DescribeInstances(context.Context, *ec2.DescribeInstancesInput, ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
+}
+
+type fisAPI interface {
+	CreateExperimentTemplate(ctx context.Context, params *fis.CreateExperimentTemplateInput, optFns ...func(*fis.Options)) (*fis.CreateExperimentTemplateOutput, error)
+	DeleteExperimentTemplate(ctx context.Context, params *fis.DeleteExperimentTemplateInput, optFns ...func(*fis.Options)) (*fis.DeleteExperimentTemplateOutput, error)
+	GetExperiment(ctx context.Context, params *fis.GetExperimentInput, optFns ...func(*fis.Options)) (*fis.GetExperimentOutput, error)
+	StartExperiment(ctx context.Context, params *fis.StartExperimentInput, optFns ...func(*fis.Options)) (*fis.StartExperimentOutput, error)
+}
+
+type iamAPI interface {
+	CreateRole(ctx context.Context, params *iam.CreateRoleInput, optFns ...func(*iam.Options)) (*iam.CreateRoleOutput, error)
+	PutRolePolicy(ctx context.Context, params *iam.PutRolePolicyInput, optFns ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error)
+}
+
+type stsAPI interface {
+	GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+}

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -1,0 +1,82 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package test
+
+import (
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+// Assert fails the test if the condition is false.
+func Assert(tb testing.TB, condition bool, msg string, v ...interface{}) {
+	if !condition {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d: "+msg+"\033[39m\n\n", append([]interface{}{filepath.Base(file), line}, v...)...)
+		tb.FailNow()
+	}
+}
+
+// Contains returns a bool indicating whether the slice contains the given val
+func Contains(slice []string, val string) bool {
+	for _, item := range slice {
+		if item == val {
+			return true
+		}
+	}
+	return false
+}
+
+// Equals fails the test if exp is not equal to act.
+func Equals(tb testing.TB, exp, act interface{}) {
+	if !reflect.DeepEqual(exp, act) {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\033[39m\n\n", filepath.Base(file), line, exp, act)
+		tb.FailNow()
+	}
+
+}
+
+// ItemsMatch fails the test if the items in exp and act slices dont match.
+// A nil argument is equivalent to an empty slice.
+func ItemsMatch(tb testing.TB, exp, act []string) {
+	if len(exp) != len(act) {
+		tb.Errorf(fmt.Sprintf("Expected %d items in slice, but was %d", len(exp), len(act)))
+	}
+	for _, v := range exp {
+		if !Contains(act, v) {
+			tb.Errorf(fmt.Sprintf("Expected to find item %s in slice, but was not found", v))
+		}
+	}
+}
+
+// Ok fails the test if an err is not nil.
+func Ok(tb testing.TB, err error) {
+	if err != nil {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d: unexpected error: %s\033[39m\n\n", filepath.Base(file), line, err.Error())
+		tb.FailNow()
+	}
+}
+
+// Nok fails the test if an err is nil.
+func Nok(tb testing.TB, err error) {
+	if err == nil {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d: unexpected success \033[39m\n\n", filepath.Base(file), line)
+		tb.FailNow()
+	}
+}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
* light refactor to `ITN` struct to accept interfaces instead of clients for easier mocking
* add unit test helper from instance-selector+aemm repos
* add mocks and unit tests to `itn` package; mostly happy paths

*Detailed Details:*
* e2e test should suffice when it comes to testing `monitor()`
* **TODO:** need to refactor how we use `NewDescribeInstancesPaginator` so I can mock and test ec2 code paths


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
