### PR TITLE
Improve e2e test

### DIFF
--- a/test/e2e/itn_e2e_test.go
+++ b/test/e2e/itn_e2e_test.go
@@ -50,14 +50,14 @@ func TestSpotITN(t *testing.T) {
 	require.NotNil(t, ec2Client)
 
 	launchTemplate, ltCleanup := CreateLTForTest(*ec2Client)
-	require.NotNil(t, launchTemplate.LaunchTemplateId)
 	defer ltCleanup()
+	require.NotNil(t, launchTemplate.LaunchTemplateId)
 	launchTemplateID := *launchTemplate.LaunchTemplateId
 	fmt.Println("✅ Launch template created")
 
 	spotInstance, fleetCleanup := CreateSpotInstance(*ec2Client, launchTemplateID)
-	require.NotNil(t, spotInstance.InstanceId)
 	defer fleetCleanup()
+	require.NotNil(t, spotInstance.InstanceId)
 	spotInstanceID := *spotInstance.InstanceId
 	fmt.Println("✅ Spot request fulfilled")
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
* adds logs to e2e test to track progress
* defer cleanup funcs **before** assertions so the deletion still occurs upon failure (i.e. can't get spot instance within retry time)
* checks that FIS template is deleted
* comparing outputs before/after changes:

**Before**
```
=== RUN   TestSpotITN
--- PASS: TestSpotITN (189.59s)
PASS
ok  	github.com/aws/itn/test/e2e	189.591s
```

**After**
```
=== RUN   TestSpotITN
✅ Launch template created
Requesting spot instance...
✅ Spot request fulfilled
Starting spot-interrupter with instance i-04b185dd35d1c5c84 ...
✅ spot-interrupter completed
✅ Fleet deleted
✅ Launch template deleted
--- PASS: TestSpotITN (193.42s)
PASS
ok      github.com/aws/itn/test/e2e     194.236s
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
