### PR TITLE
fix: Fix broken instructions for tapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The `ec2-spot-interrupter` is a simple CLI tool that triggers Amazon EC2 Spot In
 
 ```bash
 brew tap aws/tap
-brew install aws/ec2-spot-interrupter
+brew install ec2-spot-interrupter
 ```
 
 ## About


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The current docs for installation result in an error in `brew` with the error

```bash
~ brew install aws/ec2-spot-interrupter
Warning: No available formula with the name "aws/ec2-spot-interrupter". Did you mean ec2-spot-interrupter or aws/tap/ec2-spot-interrupter?
==> Searching for similarly named formulae...
This similarly named formula was found:
aws/tap/ec2-spot-interrupter ✔
To install it, run:
  brew install aws/tap/ec2-spot-interrupter ✔
==> Searching for a previously deleted formula (in the last month)...
Error: No previously deleted formula found.
```

There's no need to call `brew tap` anyways as we can just directly go to the tap

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
