### PR TITLE
fix: Fix spot interruption module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ If you've run into a bug or have a new feature request, please open an [issue](h
 Check out the open source [Amazon EC2 Spot Instances Integrations Roadmap](https://github.com/aws/ec2-spot-instances-integrations-roadmap) to see what we're working on and give us feedback! 
 
 ##  Contributing
-Contributions are welcome! Please read our [guidelines](https://github.com/aws/amazon-ec2-spot-interrupter/blob/main/CONTRIBUTING.md) and our [Code of Conduct](https://github.com/aws/itn/blob/main/CODE_OF_CONDUCT.md).
+Contributions are welcome! Please read our [guidelines](https://github.com/aws/amazon-ec2-spot-interrupter/blob/main/CONTRIBUTING.md) and our [Code of Conduct](https://github.com/aws/amazon-ec2-spot-interrupter/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 This project is licensed under the [Apache-2.0](LICENSE) License.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,9 +20,9 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/itn/pkg/cli"
-	"github.com/aws/itn/pkg/itn"
-	"github.com/aws/itn/pkg/tui"
+	"github.com/aws/amazon-ec2-spot-interrupter/pkg/cli"
+	"github.com/aws/amazon-ec2-spot-interrupter/pkg/itn"
+	"github.com/aws/amazon-ec2-spot-interrupter/pkg/tui"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/aws/itn
+module github.com/aws/amazon-ec2-spot-interrupter
 
 go 1.18
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -16,8 +16,8 @@ package cli
 import (
 	"fmt"
 
+	"github.com/aws/amazon-ec2-spot-interrupter/pkg/itn"
 	"github.com/aws/aws-sdk-go-v2/service/fis/types"
-	"github.com/aws/itn/pkg/itn"
 )
 
 func Summary(experiment *types.Experiment) string {

--- a/pkg/itn/itn_test.go
+++ b/pkg/itn/itn_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	h "github.com/aws/itn/pkg/test"
+	h "github.com/aws/amazon-ec2-spot-interrupter/pkg/test"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/fis"

--- a/pkg/tui/main.go
+++ b/pkg/tui/main.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/aws/amazon-ec2-spot-interrupter/pkg/itn"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/aws/itn/pkg/itn"
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"

--- a/pkg/tui/monitor.go
+++ b/pkg/tui/monitor.go
@@ -16,9 +16,9 @@ package tui
 import (
 	"fmt"
 
+	"github.com/aws/amazon-ec2-spot-interrupter/pkg/cli"
+	"github.com/aws/amazon-ec2-spot-interrupter/pkg/itn"
 	"github.com/aws/aws-sdk-go-v2/service/fis/types"
-	"github.com/aws/itn/pkg/cli"
-	"github.com/aws/itn/pkg/itn"
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"

--- a/pkg/tui/options.go
+++ b/pkg/tui/options.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/aws/amazon-ec2-spot-interrupter/pkg/itn"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/aws/itn/pkg/itn"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Spot interruption code module path currently does not match its Github import path which makes anyone who imports the module have to add an unnecessary `replace` directive in their `go.mod`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
